### PR TITLE
More self-sufficient ChordBox

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -299,7 +299,7 @@ function createChordElement(chord_struct) {
   chordname.append(chord_struct.name);
 
   var paper = Raphael(chordcanvas[0], 150, 140);
-  var chord = new ChordBox(paper, 22, 14, 116,116);
+  var chord = new ChordBox(paper, 14, 14, 100,116);
 
   chord.setChord(
       chord_struct.chord,

--- a/js/chord.js
+++ b/js/chord.js
@@ -20,7 +20,7 @@ ChordBox = function(paper, x, y, width, height) {
   this.num_strings = 6;
   this.num_frets = 5;
 
-  this.spacing = this.width / (this.num_strings + 1);
+  this.spacing = this.width / (this.num_strings);
   this.fret_spacing = (this.height)  / (this.num_frets + 2);
 
   // Add room on sides for finger positions on 1. and 6. string


### PR DESCRIPTION
First of all, thank you for the great piece of code. I am currently working on a project, where I need to use something for notes and chord diagrams, and both vexflow and vexchord are a godsend :)

However, in adapting VexChord to my needs, I stumbled upon two problems:

A) Current ChordBox needs to be externally padded with indeterminate amount of space (example has 30px, but this depends on size so anyone using it needs to look at implementation details)

B) When sizing down to icon-size (40x40 px - for use above musical notation) things broke down pretty horribly.

I fixed both of the issues: ChordBox will now draw within its assigned width by height box, and will work for even very small box sizes.

I also made a minor modification that I myself needed, but which might be useful for others: namely, the possibility of specifying the tuning for the chord diagram manually as the last optional argument of setChord. This also encompasses the option of not showing the tuning, if [] is passed.

In all of this, I have tried to make everything look as it did before, and to make minimal changes in other places. This hopefully explains the somewhat weird constants (22,14,116,116) and divisions by 28 or 29.
