### PR TITLE
Account for stroke width when drawing bridge

### DIFF
--- a/chordbox.js
+++ b/chordbox.js
@@ -118,10 +118,10 @@ class ChordBox {
 
     // Draw guitar bridge
     if (this.position <= 1) {
-      const fromX = this.x;
+      const fromX = this.x - (this.params.strokeWidth / 2);
       const fromY = this.y - this.metrics.bridgeStrokeWidth;
       this.canvas
-        .rect(this.x + spacing * (this.numStrings - 1) - fromX, this.y - fromY)
+        .rect(this.x + spacing * (this.numStrings - 1) - fromX + (this.params.strokeWidth / 2), this.y - fromY)
         .move(fromX, fromY)
         .stroke({ width: 0 })
         .fill(this.params.bridgeColor);


### PR DESCRIPTION
This is just a minor tweak to make the width of the bridge account for the stroke width and extend all the way to the outer edge of the strings.

**Before**
<img width="235" alt="image" src="https://github.com/user-attachments/assets/ef519ccc-f555-454b-ac35-6998ec659025" />

**After**
<img width="231" alt="image" src="https://github.com/user-attachments/assets/a2a0942e-4d20-4d2f-b1bd-d55d9bd4378d" />


> [!NOTE]  
> I know this library has been stagnant for a while, so I'm not sure if my recent PRs will be merged or not. In the meantime, I'll be maintaining a fork with all my improvements at [chordbook/vexchords](https://github.com/chordbook/vexchords).