### PR TITLE
Improve "x" for muted strings

### DIFF
--- a/chordbox.js
+++ b/chordbox.js
@@ -191,7 +191,21 @@ class ChordBox {
         .stroke({ color: this.params.strokeColor, width: this.params.strokeWidth })
         .fill(fretNum > 0 ? this.params.strokeColor : this.params.bgColor);
     } else {
-      this.drawText(x, y - this.fretSpacing, 'X');
+      const origin = {
+        x: x,
+        y: y - this.fretSpacing / 2,
+      }
+      const yOffset = this.params.circleRadius || this.metrics.circleRadius;
+      const xOffset = yOffset * 0.8;
+
+      this.canvas.line(origin.x - xOffset, origin.y - yOffset, x + xOffset, origin.y + yOffset).stroke({
+        width: this.params.strokeWidth,
+        color: this.params.strokeColor,
+      })
+      this.canvas.line(x + xOffset, origin.y - yOffset, x - xOffset, origin.y + yOffset).stroke({
+        width: this.params.strokeWidth,
+        color: this.params.strokeColor,
+      })
     }
 
     if (label) {


### PR DESCRIPTION
Manually drawing the "x" for muted strings (instead of using text rendering) results in better size and style matching with "o" for open strings. Notice the differece in line height and weight between the "x" and "o" in the diagrams below.

**Before**
<img width="588" alt="image" src="https://github.com/user-attachments/assets/ebb2507a-eef4-4888-a574-9e25d8316bf7" />

**After**
<img width="576" alt="image" src="https://github.com/user-attachments/assets/3615734b-e6e2-45ca-8021-eecb5f09f921" />