### PR TITLE
Fix fret position label, especially at small sizes

### DIFF
--- a/chordbox.js
+++ b/chordbox.js
@@ -94,7 +94,7 @@ class ChordBox {
       .fill(this.params.textColor)
       .font(textAttrs);
 
-    return text.move(x - text.length() / 2, y);
+    return text.center(x, y);
   }
 
   drawLine(x, y, newX, newY) {
@@ -127,7 +127,7 @@ class ChordBox {
         .fill(this.params.bridgeColor);
     } else {
       // Draw position number
-      this.drawText(this.x - this.spacing / 2 - this.spacing * 0.1, this.y + this.fretSpacing * this.positionText, this.position);
+      this.drawText(this.x - this.spacing / 3 - this.metrics.fontSize / 2, this.y + this.fretSpacing * this.positionText + this.fretSpacing / 2, this.position);
     }
 
     // Draw strings
@@ -149,7 +149,7 @@ class ChordBox {
     // Draw tuning keys
     if (this.params.showTuning && this.tuning.length !== 0) {
       for (let i = 0; i < Math.min(this.numStrings, this.tuning.length); i += 1) {
-        this.drawText(this.x + this.spacing * i, this.y + this.numFrets * this.fretSpacing + this.fretSpacing / 12, this.tuning[i]);
+        this.drawText(this.x + this.spacing * i, this.y + this.numFrets * this.fretSpacing + this.metrics.fontSize * .66, this.tuning[i]);
       }
     }
 
@@ -196,8 +196,7 @@ class ChordBox {
 
     if (label) {
       const fontSize = this.metrics.fontSize * 0.55;
-      const textYShift = fontSize * 0.66;
-      this.drawText(x, y - this.fretSpacing / 2 - textYShift, label, {
+      this.drawText(x, y - this.fretSpacing / 2, label, {
         weight: this.params.labelWeight,
         size: fontSize,
       })


### PR DESCRIPTION
This improves the layout of text labels, specifically to fix a bug with rendering the position label at small sizes with custom font size.

Given: 

```
draw(
  sel,
  {
    chord: [[1, 1], [2, 1], [3, 2], [4, 3], [5, 3], [6, 1]],
    position: 5,
    barres: [{ fromString: 6, toString: 1, fret: 1 }]
  },
  {
    width: 60,
    height: 80,
    showTuning: false,
    fontSize: 12
  }
);
```

**Before**
<img width="66" alt="image" src="https://github.com/user-attachments/assets/eeff0f65-e841-49e4-b8e9-3018b46691f7" />

**After**
<img width="65" alt="image" src="https://github.com/user-attachments/assets/bdec8566-3a33-4ea0-ac90-7f45ec0f5f6b" />
